### PR TITLE
Add identifier for validate tutorial

### DIFF
--- a/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
@@ -109,7 +109,6 @@ function ObjectSourceInput(props: Props) {
                     value={value.ohsomeFilter}
                     error={error?.ohsomeFilter}
                     onChange={setFieldValue}
-                    readOnly
                 />
             )}
         </Container>

--- a/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/index.tsx
+++ b/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/index.tsx
@@ -6,6 +6,7 @@ import {
     ObjectError,
 } from '@togglecorp/toggle-form';
 
+import NumberInput from '#components/NumberInput';
 import TextArea from '#components/TextArea';
 
 import { PartialValidatePropertyInputFields } from './schema';
@@ -33,6 +34,14 @@ function ValidatePropertyInput(props: Props) {
 
     return (
         <div className={_cs(className, styles.validatePropertyInput)}>
+            <NumberInput
+                label="Identifier"
+                name="identifier"
+                value={value?.identifier}
+                error={error?.identifier}
+                onChange={setFieldValue}
+                disabled={disabled}
+            />
             <TextArea
                 className={styles.geometry}
                 label="Object Geometry"

--- a/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/schema.ts
+++ b/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/schema.ts
@@ -13,6 +13,7 @@ type TaskSchema = ObjectSchema<PartialValidatePropertyInputFields>;
 
 const validatePropertyInputSchema: TaskSchema = {
     fields: (): ReturnType<TaskSchema['fields']> => ({
+        identifier: {},
         objectGeometry: {},
     }),
 };

--- a/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/styles.module.css
+++ b/app/views/EditTutorial/ScenarioPageInput/TaskInput/ValidatePropertyInput/styles.module.css
@@ -1,6 +1,8 @@
 .validate-property-input {
     .geometry {
-        font-family: var(--font-family-monospace);
-        font-size: var(--font-size-2xs);
+        textarea {
+            font-family: var(--font-family-monospace);
+            font-size: var(--font-size-2xs);
+        }
     }
 }

--- a/app/views/EditTutorial/ScenarioPageInput/ValidateScenarioPreview/index.tsx
+++ b/app/views/EditTutorial/ScenarioPageInput/ValidateScenarioPreview/index.tsx
@@ -55,7 +55,7 @@ function ValidateScenarioPreview(props: Props) {
 
             return {
                 type: 'Feature' as const,
-                geometry: JSON.parse(task.projectTypeSpecifics?.validate?.objectGeometry),
+                geometry: JSON.parse(task.projectTypeSpecifics.validate.objectGeometry),
                 properties: {
                     reference: task.reference,
                 },

--- a/app/views/EditTutorial/index.tsx
+++ b/app/views/EditTutorial/index.tsx
@@ -87,8 +87,7 @@ const TileFeaturePropertyType = type({
 const ValidateFeaturePropertyType = type.merge(
     CommonFeaturePropertyType,
     {
-        // This is not used anymore
-        // id: '"string" | "number"',
+        id: type.number,
     },
 );
 
@@ -628,6 +627,7 @@ function NewTutorial(props: Props) {
                             projectTypeSpecifics: {
                                 // FIXME: Why objectGeometry is string?
                                 validate: {
+                                    identifier: feature.properties.id,
                                     objectGeometry: JSON.stringify(feature.geometry, null, 4),
                                 } satisfies ValidatePropertyInputFields,
                             },

--- a/app/views/EditTutorial/query.ts
+++ b/app/views/EditTutorial/query.ts
@@ -72,6 +72,7 @@ query TutorialDetails($id: ID!) {
                     }
                     ... on ValidateTutorialTaskPropertyType {
                         __typename
+                        identifier
                         objectGeometry
                     }
                     ... on ValidateImageTutorialTaskPropertyType {

--- a/app/views/Teams/TeamListItem/index.tsx
+++ b/app/views/Teams/TeamListItem/index.tsx
@@ -36,7 +36,7 @@ query ContributorTeamMemberList($id: ID!, $pagination: OffsetPaginationInput) {
             totalCount
             results {
                 id
-                userId
+                firebaseId
                 username
             }
         }
@@ -88,9 +88,9 @@ function TeamListItem(props: Props) {
             cellRenderer: (item) => item.username,
         },
         {
-            id: 'userId',
+            id: 'firebaseId',
             title: 'User Id',
-            cellRenderer: (item) => item.userId,
+            cellRenderer: (item) => item.firebaseId,
         },
     ], []);
 

--- a/app/views/Teams/index.tsx
+++ b/app/views/Teams/index.tsx
@@ -32,7 +32,7 @@ query TeamsList($filters: ContributorTeamFilter, $offset: Int!, $limit: Int) {
                 results {
                     id
                     username
-                    userId
+                    firebaseId
                 }
             totalCount
             }

--- a/app/views/UserGroups/UserListItem/index.tsx
+++ b/app/views/UserGroups/UserListItem/index.tsx
@@ -31,11 +31,10 @@ query UserGroupMemberList($filters: ContributorUserGroupMembershipFilter, $pagin
             id
             user {
                 id
-                userId
+                firebaseId
                 username
             }
-            userId
-        }      
+        }
         totalCount
     }
 }
@@ -91,9 +90,9 @@ function UserListItem(props: Props) {
             cellRenderer: (item) => item.user.username,
         },
         {
-            id: 'userId',
+            id: 'id',
             title: 'User Id',
-            cellRenderer: (item) => item.user.userId,
+            cellRenderer: (item) => item.user.firebaseId,
         },
     ];
 

--- a/app/views/UserGroups/index.tsx
+++ b/app/views/UserGroups/index.tsx
@@ -40,11 +40,9 @@ query UserGroupsList($filters: ContributorUserGroupFilter, $offset: Int!, $limit
             userMemberships(pagination: $pagination) {
                 results {
                     id
-                    userId
                     user {
                         username
                         id
-                        userId
                     }
                 }
                 pageInfo {


### PR DESCRIPTION
## Changes

* Read "id" from validate tutorial scenarios
* Send "identifier" on validate tutorial
* Use firebase_id instead of user_id

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] codegen errors
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments
- [ ] conflict markers
