### PR TITLE
fix(tileserver): expect quad_key instead of quadkey for bing imagery

### DIFF
--- a/app/components/ButtonLayout/index.tsx
+++ b/app/components/ButtonLayout/index.tsx
@@ -34,6 +34,7 @@ function ButtonLayout(props: Props) {
     const {
         colorVariant = 'text',
         styleVariant = 'outline',
+        spacingOffset = -1,
         className,
         withoutPadding = false,
         disabled,
@@ -50,6 +51,7 @@ function ButtonLayout(props: Props) {
                 disabled && styles.disabled,
                 className,
             )}
+            spacingOffset={spacingOffset}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...inlineLayoutProps}
         />

--- a/app/components/InlineLayout/index.tsx
+++ b/app/components/InlineLayout/index.tsx
@@ -21,6 +21,7 @@ export interface Props {
     childrenContainerClassName?: string;
     endContainerClassName?: string;
     spacing?: SpacingType;
+    spacingOffset?: number;
     withPadding?: boolean;
 }
 
@@ -35,6 +36,7 @@ function InlineLayout(props: Props) {
         childrenContainerClassName,
         endContainerClassName,
         spacing,
+        spacingOffset,
         withPadding,
     } = props;
 
@@ -49,6 +51,7 @@ function InlineLayout(props: Props) {
     const spacingClassName = useSpacingToken({
         spacing,
         modes: spacingModes,
+        offset: spacingOffset ?? 0,
     });
 
     const innerSpacingClassName = useSpacingToken({

--- a/app/components/domain/BaseMap/index.tsx
+++ b/app/components/domain/BaseMap/index.tsx
@@ -11,6 +11,7 @@ import Map from '@togglecorp/re-map';
 import TileServerContext from '#base/context/TileServerContext';
 import { type PartialRasterTileServerInputFields } from '#components/domain/RasterTileServerInput/schema';
 import { RasterTileServerNameEnum } from '#generated/types/graphql';
+import { standardizeQuadKey } from '#utils/geo';
 
 const FALLBACK_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 const FALLBACK_TILE_CREDITS = 'Map data from OpenStreetMap';
@@ -86,7 +87,8 @@ function BaseMap(props: Props) {
             sources: {
                 'base-tile-source': {
                     type: 'raster',
-                    tiles: [url],
+                    // NOTE: maplibre uses `quadkey` but mapswipe backend uses `quad_key`
+                    tiles: [standardizeQuadKey(url)],
                     tileSize,
                     attribution: credits ?? '',
                 },

--- a/app/components/domain/RasterTileServerInput/index.tsx
+++ b/app/components/domain/RasterTileServerInput/index.tsx
@@ -154,7 +154,7 @@ function RasterTileServerInput(props: Props) {
                                 <TextInput
                                     name="url"
                                     label="Custom Imagery Server URL"
-                                    hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} or {quadkey} as placeholders and that already includes the api key."
+                                    hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} or {quad_key} as placeholders and that already includes the api key."
                                     value={value.custom?.url}
                                     error={getErrorObject(error?.custom)?.url}
                                     onChange={setCustomRasterTileServerFieldValue}

--- a/app/hooks/useSpacingToken.ts
+++ b/app/hooks/useSpacingToken.ts
@@ -17,7 +17,7 @@ import {
 interface Props {
     spacing?: SpacingType;
     modes?: SpacingMode[];
-    offset?: 0;
+    offset?: number;
 }
 
 function useSpacingToken(props: Props) {

--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -91,7 +91,7 @@ export function imageryUrlCondition(value: string | null | undefined) {
         return undefined;
     }
 
-    if (value.includes('{quadkey}')) {
+    if (value.includes('{quad_key}')) {
         return undefined;
     }
 
@@ -102,7 +102,7 @@ export function imageryUrlCondition(value: string | null | undefined) {
     ) {
         return undefined;
     }
-    return 'Imagery url must contain {x}, {y} (or {-y}) & {z} placeholders or {quadkey} placeholder.';
+    return 'Imagery url must contain {x}, {y} (or {-y}) & {z} placeholders or {quad_key} placeholder.';
 }
 
 export const projectTypeToKeyMap: Record<ProjectTypeEnum, keyof(ProjectTypeSpecificInput)> = {

--- a/app/utils/geo.ts
+++ b/app/utils/geo.ts
@@ -36,6 +36,11 @@ export function getZoomLevelFromBbox(bbox: BoundingBox | undefined) {
     return tile[2];
 }
 
+export function standardizeQuadKey(url: string) {
+    // NOTE: maplibre uses `quadkey` but mapswipe backend uses `quad_key`
+    return url.replace('{quad_key}', '{quadkey}');
+}
+
 export function tileToLng(x: number, z: number) {
     return (x / (2 ** z)) * 360 - 180;
 }

--- a/app/views/EditProject/UpdateProjectForm/CompletenessProjectSpecifics/OverlayTileServerPropertyInput/OverlayVectorTileConfigInput/VectorTileServerInput/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/CompletenessProjectSpecifics/OverlayTileServerPropertyInput/OverlayVectorTileConfigInput/VectorTileServerInput/index.tsx
@@ -161,7 +161,7 @@ function VectorTileServerInput(props: Props) {
                         <TextInput
                             name="url"
                             label="Imagery Server URL"
-                            hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} or {quadkey} as placeholders and that already includes the api key."
+                            hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} or {quad_key} as placeholders and that already includes the api key."
                             value={value.custom?.url}
                             error={getErrorObject(error?.custom)?.url}
                             onChange={setCustomTileServerFieldValue}


### PR DESCRIPTION
## Dependent on

- https://github.com/mapswipe/mapswipe-backend/pull/105

## Changes

- previously we were using quad_key (before revamp)
- maplibre uses quadkey by default

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] codegen errors
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments
- [ ] conflict markers
