### PR TITLE
fix(raster-tile): filter out raster tiles from selection if disabled

### DIFF
--- a/app/components/Checkbox/index.tsx
+++ b/app/components/Checkbox/index.tsx
@@ -3,6 +3,10 @@ import { _cs } from '@togglecorp/fujs';
 
 import ButtonLayout from '#components/ButtonLayout';
 import DefaultCheckmark, { Props as CheckmarkProps } from '#components/Checkmark';
+import InputError from '#components/InputError';
+import InputHint from '#components/InputHint';
+import ListLayout from '#components/ListLayout';
+import { SpacingType } from '#utils/styles';
 
 import styles from './styles.module.css';
 
@@ -19,6 +23,9 @@ export interface Props<NAME> {
     value: boolean | undefined | null;
     onChange: (value: boolean, name: NAME) => void;
     name: NAME;
+    hint?: React.ReactNode;
+    error?: React.ReactNode;
+    spacing?: SpacingType;
 }
 
 function Checkbox<const NAME>(props: Props<NAME>) {
@@ -35,6 +42,9 @@ function Checkbox<const NAME>(props: Props<NAME>) {
         labelClassName,
         indeterminate,
         name,
+        hint,
+        error,
+        spacing,
         ...otherProps
     } = props;
 
@@ -46,50 +56,65 @@ function Checkbox<const NAME>(props: Props<NAME>) {
         [name, onChange],
     );
 
-    const className = _cs(
-        classNameFromProps,
-        indeterminate && styles.indeterminate,
-        !indeterminate && value && styles.checked,
-        readOnly && styles.readOnly,
-    );
-
     return (
         <label // eslint-disable-line jsx-a11y/label-has-associated-control
             className={styles.checkbox}
             title={tooltip}
         >
-            <ButtonLayout
-                className={className}
-                start={(
-                    <Checkmark
-                        className={_cs(checkmarkClassName, styles.checkmark)}
-                        value={value ?? false}
-                        indeterminate={indeterminate}
-                    />
-                )}
-                spacingOffset={-2}
-                withoutPadding
-                disabled={disabled}
-                styleVariant="transparent"
+            <ListLayout
+                className={classNameFromProps}
+                spacing={spacing}
+                spacingOffset={-1}
+                layout="block"
             >
-                <input
-                    onChange={handleChange}
-                    className={styles.input}
-                    type="checkbox"
-                    checked={value ?? false}
-                    disabled={disabled || readOnly}
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...otherProps}
-                />
-                <div
+                <ButtonLayout
                     className={_cs(
-                        // styles.label,
-                        labelClassName,
+                        indeterminate && styles.indeterminate,
+                        !indeterminate && value && styles.checked,
+                        readOnly && styles.readOnly,
                     )}
+                    start={(
+                        <Checkmark
+                            className={_cs(checkmarkClassName, styles.checkmark)}
+                            value={value ?? false}
+                            indeterminate={indeterminate}
+                        />
+                    )}
+                    spacingOffset={-2}
+                    withoutPadding
+                    disabled={disabled}
+                    styleVariant="transparent"
                 >
-                    { label }
-                </div>
-            </ButtonLayout>
+                    <input
+                        onChange={handleChange}
+                        className={styles.input}
+                        type="checkbox"
+                        checked={value ?? false}
+                        disabled={disabled || readOnly}
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...otherProps}
+                    />
+                    <div
+                        className={_cs(
+                            // styles.label,
+                            labelClassName,
+                        )}
+                    >
+                        { label }
+                    </div>
+                </ButtonLayout>
+                {/* FIXME: Style these */}
+                {error && (
+                    <InputError>
+                        {error}
+                    </InputError>
+                )}
+                {!error && hint && (
+                    <InputHint>
+                        {hint}
+                    </InputHint>
+                )}
+            </ListLayout>
         </label>
     );
 }

--- a/app/components/ZoomLevelSelectInput/index.tsx
+++ b/app/components/ZoomLevelSelectInput/index.tsx
@@ -83,7 +83,7 @@ function ZoomLevelSelectInput<const NAME>(props: Props<NAME>) {
             error={error}
             disabled={disabled}
             nonClearable
-            hint="We use the Tile Map Service zoom levels. Please check for your area which zoom level is available. If you use a custom tile server you may be able to use even higher zoom levels."
+            hint="We use the zoom levels that the tile server provides. Please check for your area which zoom level is available before you create a project."
         />
     );
 }

--- a/app/components/domain/CustomOptionInput/SubOptionInput/index.tsx
+++ b/app/components/domain/CustomOptionInput/SubOptionInput/index.tsx
@@ -81,6 +81,7 @@ function SubOptionInput(props: Props) {
                     error={error?.value}
                     disabled={disabled}
                     spacing="sm"
+                    hint="Choose a value for each sub-option"
                 />
                 <GridLayoutItem columnSpan={2}>
                     <TextInput
@@ -91,6 +92,7 @@ function SubOptionInput(props: Props) {
                         error={error?.description}
                         disabled={disabled}
                         spacing="sm"
+                        hint="Provide a brief description for each sub-option"
                     />
                 </GridLayoutItem>
             </ListLayout>

--- a/app/components/domain/CustomOptionInput/index.tsx
+++ b/app/components/domain/CustomOptionInput/index.tsx
@@ -115,6 +115,7 @@ function CustomOptionInput(props: Props) {
                         error={error?.title}
                         disabled={disabled}
                         spacing="sm"
+                        hint="Provide 'Title' for each answer option (e.g. Yes, No, Offset)"
                     />
                     <NumberInput
                         label="Value"
@@ -124,6 +125,7 @@ function CustomOptionInput(props: Props) {
                         error={error?.value}
                         disabled={disabled}
                         spacing="sm"
+                        hint="Choose the value for each answer choice (e.g. 1 - Yes, 0 - No, 3 - Offset)"
                     />
                     <IconSelectInput
                         label="Icon"
@@ -134,6 +136,7 @@ function CustomOptionInput(props: Props) {
                         nonClearable
                         disabled={disabled}
                         spacing="sm"
+                        hint="Choose the icon for each answer choice (e.g. Checkmark - Yes, Close - No, Flag - Offset)"
                     />
                     <ColorSelectInput
                         label="Color"
@@ -143,6 +146,7 @@ function CustomOptionInput(props: Props) {
                         error={error?.iconColor}
                         disabled={disabled}
                         spacing="sm"
+                        hint="Choose the color for each answer choice (e.g. Green - Yes, Red - No, Orange - Offset)"
                     />
                     <GridLayoutItem columnSpan={2}>
                         <TextArea
@@ -153,6 +157,7 @@ function CustomOptionInput(props: Props) {
                             error={error?.description}
                             disabled={disabled}
                             spacing="sm"
+                            placeholder="Provide a brief description for each answer option (e.g. for Yes - The mapped outline does match the building footprint)"
                         />
                     </GridLayoutItem>
                 </ListLayout>

--- a/app/components/domain/RasterTileServerInput/index.tsx
+++ b/app/components/domain/RasterTileServerInput/index.tsx
@@ -23,13 +23,8 @@ import ListLayout from '#components/ListLayout';
 import NumberInput from '#components/NumberInput';
 import RadioInput from '#components/RadioInput';
 import TextInput from '#components/TextInput';
-import EnumsContext from '#contexts/EnumsContext';
 import TileServerContext from '#contexts/TileServerContext';
 import { RasterTileServerNameEnum } from '#generated/types/graphql';
-import {
-    keySelector,
-    labelSelector,
-} from '#utils/common';
 
 import BaseMap from '../BaseMap';
 import GeoJsonAssetMapSource from '../GeoJsonAssetMapSource';
@@ -41,6 +36,18 @@ import {
     rasterTileServerNameToTileInputKey,
     TileInputKeys,
 } from './schema';
+
+interface Option {
+    type: RasterTileServerNameEnum;
+    label: string;
+}
+
+function imageryKeySelector(item: Option) {
+    return item.type;
+}
+function imageryLabelSelector(item: Option) {
+    return item.label;
+}
 
 interface Props {
     label?: React.ReactNode;
@@ -75,8 +82,13 @@ function RasterTileServerInput(props: Props) {
 
     const error = getErrorObject(formError);
 
-    const { rasterTileServerNameOptions } = useContext(EnumsContext);
+    const { raster: rasterTileServerNameOptions } = useContext(TileServerContext);
     const [zoomView, setZoomView] = useState<MapZoomViewType>('aoiBounds');
+
+    const workingRasterTileServerNameOptions = useMemo(
+        () => rasterTileServerNameOptions.filter((option) => !option.disabled) ?? [],
+        [rasterTileServerNameOptions],
+    );
 
     const fieldName = (isDefined(value)
         && isDefined(value.name)
@@ -133,11 +145,11 @@ function RasterTileServerInput(props: Props) {
                     <RadioInput
                         label="Imagery server"
                         name="name"
-                        options={rasterTileServerNameOptions ?? []}
+                        options={workingRasterTileServerNameOptions}
                         value={value?.name}
                         onChange={handleImageryServerChange}
-                        keySelector={keySelector}
-                        labelSelector={labelSelector}
+                        keySelector={imageryKeySelector}
+                        labelSelector={imageryLabelSelector}
                         error={error?.name}
                         disabled={disabled}
                         radioListLayout="block"

--- a/app/components/domain/RasterTileServerInput/index.tsx
+++ b/app/components/domain/RasterTileServerInput/index.tsx
@@ -153,6 +153,7 @@ function RasterTileServerInput(props: Props) {
                         error={error?.name}
                         disabled={disabled}
                         radioListLayout="block"
+                        hint="Select the tile server providing satellite imagery tiles for your project. Make sure you have permission if using custom imagery."
                     />
                     {isDefined(value)
                         && isDefined(value.name)
@@ -184,7 +185,7 @@ function RasterTileServerInput(props: Props) {
                                 <TextInput
                                     name="credits"
                                     label="Imagery Credits"
-                                    hint="Insert appropriate imagery credits"
+                                    hint="Insert appropriate imagery credits if you are using a custom tile server."
                                     value={value.custom?.credits}
                                     error={getErrorObject(error?.custom)?.credits}
                                     onChange={setCustomRasterTileServerFieldValue}

--- a/app/components/domain/RasterTileServerOutput/index.tsx
+++ b/app/components/domain/RasterTileServerOutput/index.tsx
@@ -12,7 +12,6 @@ import {
 import Button from '#components/Button';
 import Container, { ContainerProps } from '#components/Container';
 import TextOutput from '#components/TextOutput';
-import EnumsContext from '#contexts/EnumsContext';
 import TileServerContext from '#contexts/TileServerContext';
 import {
     ProjectRasterTileServerConfig,
@@ -37,8 +36,16 @@ function RasterTileServerOutput(props: Props) {
         ...containerProps
     } = props;
 
-    const { rasterTileServerNameMapping } = useContext(EnumsContext);
     const { raster: rasterTileServers } = useContext(TileServerContext);
+
+    const rasterTileServerNameMapping = useMemo(
+        () => listToMap(
+            rasterTileServers,
+            (item) => item.type,
+            (item) => item,
+        ),
+        [rasterTileServers],
+    );
 
     const {
         url,
@@ -106,7 +113,7 @@ function RasterTileServerOutput(props: Props) {
             */}
             <TextOutput
                 label="Supported zoom"
-                value={`${formatNumber(minZoom)} - ${formatNumber(maxZoom)}`}
+                value={`${formatNumber(minZoom) ?? '--'} to ${formatNumber(maxZoom) ?? '--'}`}
             />
             <TextOutput
                 label="Credits"

--- a/app/components/domain/VectorTileServerInput/index.tsx
+++ b/app/components/domain/VectorTileServerInput/index.tsx
@@ -137,6 +137,7 @@ function VectorTileServerInput(props: Props) {
                 error={error?.name}
                 onChange={handleImageryServerChange}
                 disabled={disabled}
+                hint="Select the overlay source"
             />
             {isDefined(value)
                 && isDefined(value.name)
@@ -150,6 +151,7 @@ function VectorTileServerInput(props: Props) {
                             error={getErrorObject(error?.[fieldName])?.credits}
                             onChange={setCommonTileServerFieldValue}
                             disabled={disabled}
+                            hint="Insert appropriate imagery credits if you are using a custom tile server."
                         />
                         <SelectInput
                             label="Source layer"
@@ -160,6 +162,7 @@ function VectorTileServerInput(props: Props) {
                             options={sourceLayerOptions}
                             keySelector={keySelector}
                             labelSelector={labelSelector}
+                            hint="Select the vector features that you want contributors to check for the presence of"
                         />
                     </>
                 )}
@@ -171,7 +174,7 @@ function VectorTileServerInput(props: Props) {
                         <TextInput
                             name="url"
                             label="Imagery Server URL"
-                            hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} or {quad_key} as placeholders and that already includes the api key."
+                            hint="Make sure you have permission. Add a custom tile server URL that uses {x}, {y} (or {-y}) & {z} as placeholders and that already includes the api key."
                             value={value.custom?.url}
                             error={getErrorObject(error?.custom)?.url}
                             onChange={setCustomTileServerFieldValue}
@@ -180,7 +183,7 @@ function VectorTileServerInput(props: Props) {
                         <TextInput
                             name="credits"
                             label="Imagery Credits"
-                            hint="Insert appropriate imagery credits"
+                            hint="Insert appropriate imagery credits if you are using a custom tile server."
                             value={value.custom?.credits}
                             error={getErrorObject(error?.[fieldName])?.credits}
                             onChange={setCustomTileServerFieldValue}
@@ -192,6 +195,7 @@ function VectorTileServerInput(props: Props) {
                             value={value.custom?.sourceLayer}
                             error={getErrorObject(error?.[fieldName])?.sourceLayer}
                             onChange={setCustomTileServerFieldValue}
+                            hint="Select the vector features that you want contributors to check for the presence of"
                         />
                         <ListLayout layout="grid">
                             <NumberInput

--- a/app/components/domain/VectorTileServerInput/index.tsx
+++ b/app/components/domain/VectorTileServerInput/index.tsx
@@ -22,7 +22,6 @@ import NumberInput from '#components/NumberInput';
 import RadioInput from '#components/RadioInput';
 import SelectInput from '#components/SelectInput';
 import TextInput from '#components/TextInput';
-import EnumsContext from '#contexts/EnumsContext';
 import TileServerContext from '#contexts/TileServerContext';
 import { VectorTileServerNameEnum } from '#generated/types/graphql';
 import {
@@ -37,6 +36,18 @@ import {
     VectorTileInputKeys,
     vectorTileServerNameToTileInputKey,
 } from './schema';
+
+interface Option {
+    type: VectorTileServerNameEnum;
+    label: string;
+}
+
+function imageryKeySelector(item: Option) {
+    return item.type;
+}
+function imageryLabelSelector(item: Option) {
+    return item.label;
+}
 
 interface Props {
     label?: React.ReactNode;
@@ -56,8 +67,6 @@ function VectorTileServerInput(props: Props) {
     } = props;
 
     const error = getErrorObject(formError);
-
-    const { vectorTileServerNameOptions } = useContext(EnumsContext);
 
     const fieldName = (isDefined(value)
         && isDefined(value.name)
@@ -83,6 +92,7 @@ function VectorTileServerInput(props: Props) {
     );
 
     const { vector: vectorTileServers } = useContext(TileServerContext);
+
     const tileServerMapping = useMemo(() => (
         listToMap(vectorTileServers, ({ type }) => type)
     ), [vectorTileServers]);
@@ -120,9 +130,9 @@ function VectorTileServerInput(props: Props) {
             <RadioInput
                 label="Imagery Server"
                 name="name"
-                options={vectorTileServerNameOptions}
-                keySelector={keySelector}
-                labelSelector={labelSelector}
+                options={vectorTileServers}
+                keySelector={imageryKeySelector}
+                labelSelector={imageryLabelSelector}
                 value={value?.name}
                 error={error?.name}
                 onChange={handleImageryServerChange}

--- a/app/components/domain/VectorTileServerOutput/index.tsx
+++ b/app/components/domain/VectorTileServerOutput/index.tsx
@@ -12,7 +12,6 @@ import {
 import Button from '#components/Button';
 import Container from '#components/Container';
 import TextOutput from '#components/TextOutput';
-import EnumsContext from '#contexts/EnumsContext';
 import TileServerContext from '#contexts/TileServerContext';
 import {
     ProjectVectorTileServerConfig,
@@ -32,8 +31,16 @@ function VectorTileServerOutput(props: Props) {
         value,
     } = props;
 
-    const { vectorTileServerNameMapping } = useContext(EnumsContext);
     const { vector: vectorTileServers } = useContext(TileServerContext);
+
+    const vectorTileServerNameMapping = useMemo(
+        () => listToMap(
+            vectorTileServers,
+            (item) => item.type,
+            (item) => item,
+        ),
+        [vectorTileServers],
+    );
 
     const {
         url,

--- a/app/contexts/EnumsContext.ts
+++ b/app/contexts/EnumsContext.ts
@@ -7,8 +7,6 @@ export interface EnumsContextProps {
     validateImageSourceTypeOptions: AllEnumsQuery['enums']['ValidateImageSourceTypeEnum'],
     projectStatusOptions: AllEnumsQuery['enums']['ProjectStatusEnum'],
     projectTypeOptions: AllEnumsQuery['enums']['ProjectTypeEnum'],
-    rasterTileServerNameOptions: AllEnumsQuery['enums']['RasterTileServerNameEnum'],
-    vectorTileServerNameOptions: AllEnumsQuery['enums']['VectorTileServerNameEnum'],
     tutorialInformationPageBlockTypeOptions: AllEnumsQuery['enums']['TutorialInformationPageBlockTypeEnum'],
     iconOptions: AllEnumsQuery['enums']['IconEnum'],
     overlayLayerTypeOptions: AllEnumsQuery['enums']['OverlayLayerTypeEnum'],
@@ -30,14 +28,6 @@ export interface EnumsContextProps {
     projectTypeMapping: Record<
         AllEnumsQuery['enums']['ProjectTypeEnum'][number]['key'],
         AllEnumsQuery['enums']['ProjectTypeEnum'][number]
-    > | undefined;
-    rasterTileServerNameMapping: Record<
-        AllEnumsQuery['enums']['RasterTileServerNameEnum'][number]['key'],
-        AllEnumsQuery['enums']['RasterTileServerNameEnum'][number]
-    > | undefined;
-    vectorTileServerNameMapping: Record<
-        AllEnumsQuery['enums']['VectorTileServerNameEnum'][number]['key'],
-        AllEnumsQuery['enums']['VectorTileServerNameEnum'][number]
     > | undefined;
     tutorialInformationPageBlockTypeMapping: Record<
         AllEnumsQuery['enums']['TutorialInformationPageBlockTypeEnum'][number]['key'],
@@ -66,8 +56,6 @@ export const defaultAllEnumsValue: EnumsContextProps = {
     validateImageSourceTypeOptions: [],
     projectStatusOptions: [],
     projectTypeOptions: [],
-    rasterTileServerNameOptions: [],
-    vectorTileServerNameOptions: [],
     tutorialInformationPageBlockTypeOptions: [],
     iconOptions: [],
     overlayLayerTypeOptions: [],
@@ -78,8 +66,6 @@ export const defaultAllEnumsValue: EnumsContextProps = {
     validateImageSourceTypeMapping: undefined,
     projectStatusMapping: undefined,
     projectTypeMapping: undefined,
-    rasterTileServerNameMapping: undefined,
-    vectorTileServerNameMapping: undefined,
     tutorialInformationPageBlockTypeMapping: undefined,
     iconMapping: undefined,
     overlayLayerTypeMapping: undefined,

--- a/app/views/EditProject/ProjectAdditionalInputs/index.tsx
+++ b/app/views/EditProject/ProjectAdditionalInputs/index.tsx
@@ -63,7 +63,7 @@ function ProjectAdditionalInputs(props: Props) {
                         onChange={setFieldValue}
                         error={error?.verificationNumber}
                         disabled={disabled}
-                        hint="How many people do you want to see every tile before you consider it finished? (default is 3 - more is recommended for harder tasks, but this will also make project take longer)"
+                        hint="How many people do you want to see every task before you consider it finished? Default is 3, but 5 or more is recommended for harder tasks. Note that the higher the number the longer the project will take to complete."
                     />
                     <NumberInput
                         label="Group size"
@@ -72,7 +72,7 @@ function ProjectAdditionalInputs(props: Props) {
                         onChange={setFieldValue}
                         error={error?.groupSize}
                         disabled={disabled}
-                        hint="How big should a mapping session be? Group size refers to the number of tasks per mapping session."
+                        hint="How big should an activity session be? Group size refers to the number of tasks per session."
                     />
                     <NumberInput
                         label="Max tasks per user"

--- a/app/views/EditProject/UpdateProcessedProjectForm/index.tsx
+++ b/app/views/EditProject/UpdateProcessedProjectForm/index.tsx
@@ -395,7 +395,7 @@ function UpdateProcessedProjectForm(props: Props) {
                     error={error?.tutorial}
                     disabled={baseInputsDisabled || readOnly}
                     projectType={projectData.project.projectType}
-                    hint="Please note that you'll only be able to select the tutorial of same project type"
+                    hint="Please note that you'll only be able to select the tutorial of same project type."
                 />
             </Container>
         </PageLayout>

--- a/app/views/EditProject/UpdateProjectForm/CompletenessProjectSpecifics/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/CompletenessProjectSpecifics/index.tsx
@@ -61,7 +61,7 @@ function CompletenessProjectSpecifics(props: Props) {
                 value={value?.aoiGeometry}
                 error={error?.aoiGeometry}
                 inputType={ProjectAssetInputTypeEnum.AoiGeometry}
-                hint="Upload your project area as GeoJSON File (max. 1MB)"
+                hint="Upload your project area as GeoJSON File (max. 1MB). Make sure that you provide a single polygon geometry."
                 disabled={disabled}
                 withoutPreview
             />

--- a/app/views/EditProject/UpdateProjectForm/StreetProjectSpecifics/StreetMapillaryImageFiltersInput/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/StreetProjectSpecifics/StreetMapillaryImageFiltersInput/index.tsx
@@ -45,6 +45,7 @@ function StreetMapillaryImageFiltersInput(props: Props) {
                     onChange={setFieldValue}
                     error={error?.startTime}
                     disabled={disabled}
+                    hint="Choose a date range to filter images by the date they were captured at. Empty indicates that images of all capture dates are used. "
                 />
                 <TextInput
                     name="endTime"
@@ -53,6 +54,7 @@ function StreetMapillaryImageFiltersInput(props: Props) {
                     onChange={setFieldValue}
                     error={error?.endTime}
                     disabled={disabled}
+                    hint="Choose a date range to filter images by the date they were captured at. Empty indicates that images of all capture dates are used."
                 />
                 <TextInput
                     name="creatorId"
@@ -61,6 +63,7 @@ function StreetMapillaryImageFiltersInput(props: Props) {
                     error={error?.creatorId}
                     onChange={setFieldValue}
                     disabled={disabled}
+                    hint="Provide a valid Mapillary creator ID to filter for images belonging to a specific Mapillary user."
                 />
                 <TextInput
                     name="organizationId"
@@ -69,6 +72,7 @@ function StreetMapillaryImageFiltersInput(props: Props) {
                     error={error?.organizationId}
                     onChange={setFieldValue}
                     disabled={disabled}
+                    hint="Provide a valid Mapillary organization ID to filter for images belonging to a specific organization. Empty indicates that no filter is set on organization."
                 />
                 <NumberInput
                     name="samplingThreshold"
@@ -77,23 +81,26 @@ function StreetMapillaryImageFiltersInput(props: Props) {
                     error={error?.samplingThreshold}
                     onChange={setFieldValue}
                     disabled={disabled}
+                    hint="What should be the minimum distance (in km) between images on the same Mapillary sequence? Empty indicates that all images on each sequence are used."
                 />
             </ListLayout>
             <Checkbox
                 name="isPano"
                 label="Only use 360 degree panaroma images"
                 value={value?.isPano}
-                // error={error?.isPano}
+                error={error?.isPano}
                 onChange={setFieldValue}
                 disabled={disabled}
+                hint="If unchecked, both 360 degree panorama and classic images are used in the project"
             />
             <Checkbox
                 name="randomizeOrder"
                 label="Randomize the order of images in the project"
                 value={value?.randomizeOrder}
-                // error={error?.randomizeOrder}
+                error={error?.randomizeOrder}
                 onChange={setFieldValue}
                 disabled={disabled}
+                hint="If unchecked, tasks in the project will be in sequential order."
             />
         </Container>
     );

--- a/app/views/EditProject/UpdateProjectForm/StreetProjectSpecifics/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/StreetProjectSpecifics/index.tsx
@@ -124,7 +124,7 @@ function StreetProjectSpecifics(props: Props) {
                     error={error?.aoiGeometry}
                     inputType={ProjectAssetInputTypeEnum.AoiGeometry}
                     disabled={disabled}
-                    hint="Upload your project area as GeoJSON File (max. 1MB)"
+                    hint="Upload your project area as GeoJSON File (max. 1MB). Make sure that you provide a single polygon geometry."
                 />
             </Container>
             <StreetMapillaryImageFiltersInput

--- a/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
@@ -37,7 +37,7 @@ import { PartialValidateObjectSourceInputFields } from './schema';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TEST_AOI_OBJECTS_QUERY = gql`
-query TestAoiObjects($assetId: ID, $projectId: ID, $ohsomeFilter: String) {
+query TestAoiObjects($assetId: ID!, $projectId: ID!, $ohsomeFilter: String!) {
     testAoiObjects(assetId: $assetId, projectId: $projectId, ohsomeFilter: $ohsomeFilter) {
         ok
         error
@@ -51,7 +51,7 @@ query TestAoiObjects($assetId: ID, $projectId: ID, $ohsomeFilter: String) {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TEST_TASKING_MANAGER_PROJECT_QUERY = gql`
-query TestTaskingManagerProject($hotTmId: String, $ohsomeFilter: String) {
+query TestTaskingManagerProject($hotTmId: String!, $ohsomeFilter: String!) {
     testTaskingManagerProject(hotTmId: $hotTmId, ohsomeFilter: $ohsomeFilter) {
         ok
         error
@@ -93,8 +93,8 @@ function ObjectSourceInput(props: Props) {
     ] = useTestAoiObjectsQuery({
         variables: {
             projectId,
-            assetId: value?.aoiGeometry,
-            ohsomeFilter: value?.ohsomeFilter,
+            assetId: value?.aoiGeometry ?? '',
+            ohsomeFilter: value?.ohsomeFilter ?? '',
         },
         pause: true,
     });
@@ -108,8 +108,8 @@ function ObjectSourceInput(props: Props) {
         triggerTestTaskingManagerProject,
     ] = useTestTaskingManagerProjectQuery({
         variables: {
-            hotTmId: value?.taskingManagerProjectId,
-            ohsomeFilter: value?.ohsomeFilter,
+            hotTmId: value?.taskingManagerProjectId ?? '',
+            ohsomeFilter: value?.ohsomeFilter ?? '',
         },
         pause: true,
     });

--- a/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
+++ b/app/views/EditProject/UpdateProjectForm/ValidateProjectSpecifics/ObjectSourceInput/index.tsx
@@ -315,7 +315,7 @@ function ObjectSourceInput(props: Props) {
                     value={value.aoiGeometry}
                     error={error?.aoiGeometry}
                     inputType={ProjectAssetInputTypeEnum.AoiGeometry}
-                    hint="Upload your project area as GeoJSON File (max. 1MB)"
+                    hint="Upload your project area as GeoJSON File (max. 1MB). Make sure that you provide a single polygon geometry."
                     disabled={disabled}
                     withoutPreview
                 />

--- a/app/views/NewProject/ProjectGeneralInputs/index.tsx
+++ b/app/views/NewProject/ProjectGeneralInputs/index.tsx
@@ -62,12 +62,12 @@ const hintText: Record<
         [ProjectTypeEnum.Street]: 'Enter the description for your project. (markdown syntax is supported)',
     },
     topic: {
-        [ProjectTypeEnum.Find]: 'Enter the title of your project. It should begin with project type. (e.g., "Find Features") ',
-        [ProjectTypeEnum.Compare]: 'Enter the title of your project. It should begin with project type. (e.g., "Compare Dates")',
-        [ProjectTypeEnum.Validate]: 'Enter the title of your project. It should begin with project type. (e.g., "Validate Footprints")',
-        [ProjectTypeEnum.ValidateImage]: 'Enter the title of your project. It should begin with project type. (e.g., "Assess Images")',
-        [ProjectTypeEnum.Completeness]: 'Enter the title of your project. It should begin with project type. (e.g., "Check Completeness")',
-        [ProjectTypeEnum.Street]: 'Enter the title of your project. It should begin with project type. (e.g., "View Streets") ',
+        [ProjectTypeEnum.Find]: 'Enter the title of your project.',
+        [ProjectTypeEnum.Compare]: 'Enter the title of your project.',
+        [ProjectTypeEnum.Validate]: 'Enter the title of your project.',
+        [ProjectTypeEnum.ValidateImage]: 'Enter the title of your project.',
+        [ProjectTypeEnum.Completeness]: 'Enter the title of your project.',
+        [ProjectTypeEnum.Street]: 'Enter the title of your project.',
     },
     projectInstruction: {
         [ProjectTypeEnum.Find]: 'What should the users look for (e.g. You are looking for: buildings, destroyed buildings, cars, trees, etc.)',
@@ -89,7 +89,7 @@ const hintText: Record<
         [ProjectTypeEnum.Find]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
         [ProjectTypeEnum.Compare]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
         [ProjectTypeEnum.Validate]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
-        [ProjectTypeEnum.ValidateImage]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app).',
+        [ProjectTypeEnum.ValidateImage]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
         [ProjectTypeEnum.Completeness]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
         [ProjectTypeEnum.Street]: 'Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)',
     },
@@ -105,7 +105,7 @@ const hintText: Record<
         [ProjectTypeEnum.Find]: 'Enter the region/location of your project (eg: City, Country)',
         [ProjectTypeEnum.Compare]: 'Enter the region/location of your project (eg: City, Country)',
         [ProjectTypeEnum.Validate]: 'Enter the region/location of your project (eg: City, Country)',
-        [ProjectTypeEnum.ValidateImage]: 'Enter the project location in the format "city/region, country".',
+        [ProjectTypeEnum.ValidateImage]: 'Enter the region/location of your project (eg: City, Country)',
         [ProjectTypeEnum.Completeness]: 'Enter the region/location of your project (eg: City, Country)',
         [ProjectTypeEnum.Street]: 'Enter the region/location of your project (eg: City, Country)',
     },
@@ -113,17 +113,17 @@ const hintText: Record<
         [ProjectTypeEnum.Find]: 'Which group, institution or community is requesting this project?',
         [ProjectTypeEnum.Compare]: 'Which group, institution or community is requesting this project?',
         [ProjectTypeEnum.Validate]: 'Which group, institution or community is requesting this project?',
-        [ProjectTypeEnum.ValidateImage]: 'Which group, institution, or community is requesting this project?',
+        [ProjectTypeEnum.ValidateImage]: 'Which group, institution or community is requesting this project?',
         [ProjectTypeEnum.Completeness]: 'Which group, institution or community is requesting this project?',
         [ProjectTypeEnum.Street]: 'Which group, institution or community is requesting this project?',
     },
     team: {
-        [ProjectTypeEnum.Find]: 'Please note that if \'private\', this project will only be visible to the selected  team members',
-        [ProjectTypeEnum.Compare]: 'Please note that if selected, this project will only be visible to the team members',
-        [ProjectTypeEnum.Validate]: 'Please note that if selected, this project will only be visible to the team members',
-        [ProjectTypeEnum.ValidateImage]: 'Please note that if selected, this project will only be visible to the team members.',
-        [ProjectTypeEnum.Completeness]: 'Please note that if \'private\', this project will only be visible to the selected  team members',
-        [ProjectTypeEnum.Street]: 'Please note that if \'private\', this project will only be visible to the selected  team members',
+        [ProjectTypeEnum.Find]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
+        [ProjectTypeEnum.Compare]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
+        [ProjectTypeEnum.Validate]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
+        [ProjectTypeEnum.ValidateImage]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
+        [ProjectTypeEnum.Completeness]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
+        [ProjectTypeEnum.Street]: 'Please note that if \'private\', this project will only be visible to the assigned team members. Data results will still be public.',
     },
 };
 
@@ -249,6 +249,7 @@ function ProjectGeneralInputs(props: Props) {
                 name={undefined}
                 value={projectNameResult?.projectName}
                 placeholder="Please select all the fields above to see the preview"
+                hint="We will generate your project name based on your inputs above."
                 readOnly
             />
             <MarkdownEditor

--- a/app/views/RootLayout/index.tsx
+++ b/app/views/RootLayout/index.tsx
@@ -41,6 +41,7 @@ query TileServers {
             credits
             maxZoom
             minZoom
+            disabled
         }
         vector {
             label
@@ -75,14 +76,6 @@ query AllEnums {
             label
         }
         ProjectTypeEnum {
-            key
-            label
-        }
-        RasterTileServerNameEnum {
-            key
-            label
-        }
-        VectorTileServerNameEnum {
             key
             label
         }
@@ -201,8 +194,6 @@ function RootLayout() {
         validateImageSourceTypeOptions: allEnumsResponse?.enums.ValidateImageSourceTypeEnum ?? [],
         projectStatusOptions: allEnumsResponse?.enums.ProjectStatusEnum ?? [],
         projectTypeOptions: allEnumsResponse?.enums.ProjectTypeEnum ?? [],
-        rasterTileServerNameOptions: allEnumsResponse?.enums.RasterTileServerNameEnum ?? [],
-        vectorTileServerNameOptions: allEnumsResponse?.enums.VectorTileServerNameEnum ?? [],
         tutorialInformationPageBlockTypeOptions: allEnumsResponse
             ?.enums.TutorialInformationPageBlockTypeEnum ?? [],
         iconOptions: allEnumsResponse?.enums.IconEnum ?? [],
@@ -223,14 +214,6 @@ function RootLayout() {
         ),
         projectTypeMapping: listToMap(
             allEnumsResponse?.enums.ProjectTypeEnum,
-            ({ key }) => key,
-        ),
-        rasterTileServerNameMapping: listToMap(
-            allEnumsResponse?.enums.RasterTileServerNameEnum,
-            ({ key }) => key,
-        ),
-        vectorTileServerNameMapping: listToMap(
-            allEnumsResponse?.enums.VectorTileServerNameEnum,
             ({ key }) => key,
         ),
         tutorialInformationPageBlockTypeMapping: listToMap(


### PR DESCRIPTION
## Depends on

- https://github.com/mapswipe/mapswipe-backend/pull/222

## Changes

* Update tooltips
* Filter out disabled raster tiles

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] codegen errors
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments
- [ ] conflict markers
